### PR TITLE
Pass data object when register client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ $ up serve [OPTION]
 
 ## JavaScript API
 ``` javascript
+var http = require('http')
 var createClient = require('underpass/src/client')
 var createServer = require('underpass/src/server')
 
@@ -78,12 +79,21 @@ var server = createServer({
   // }
 })
 
+server.on('register', (name, data) => {
+  console.log('name', name);
+  console.log('data', data);
+});
+
 var client = createClient({
   tunnelHost: 'localhost',
   tunnelPort: '9000',
   controlPort: '9001',
   name: 'upper-caser',
   port: '8080',
+  data: {
+    key1: 1,
+    key2: 'text'
+  }
   // secure: true
 })
 

--- a/src/client.js
+++ b/src/client.js
@@ -13,6 +13,7 @@ module.exports = function (opts) {
   var tunnelHost = opts.tunnelHost
   var rpcTimeout = opts.rpcTimeout || 3000
   var ping = opts.ping !== false
+  var data = opts.data
 
   var socket = secure
     ? tls.connect(controlPort, tunnelHost, tlsOpts, onconnect)
@@ -66,7 +67,7 @@ module.exports = function (opts) {
       }
     }
 
-    tunnelControl.call('register', name, (err, _session, _port) => {
+    tunnelControl.call('register', name, data, (err, _session, _port) => {
       if (err) return socket.emit('error', err)
       session = _session
       socket.emit('ready', _port)

--- a/src/control-server.js
+++ b/src/control-server.js
@@ -23,16 +23,16 @@ module.exports = function (opts) {
   })
 
   function onconnection (socket) {
+    var _this = this;
     var address = `${socket.remoteAddress}:${socket.remotePort}`
     debug(`connection from ${address} did open`)
-
     var host = rpc(socket)
     host.timeout = rpcTimeout
     host.requests = []
 
     host.methods.ping = cb => cb()
 
-    host.methods.register = function (name, cb) {
+    host.methods.register = function (name, data, cb) {
       var otherHost = hosts.byName[name]
       if (otherHost) {
         debug(`pinging existing registrant for "${name}"`)
@@ -54,6 +54,7 @@ module.exports = function (opts) {
         hosts.byName[host.name] = host
         hosts.bySession[host.session] = host
         debug(`connection from ${address} registered as "${name}"`)
+        _this.emit('register', name, data)
         cb(null, host.session, externalPort)
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,7 @@ module.exports = function (opts) {
   // for name registration and new socket creation
   opts.controlServer = controlServer(opts)
   opts.controlServer.on('ready', onready)
+  opts.controlServer.on('register', (name, data)=>{opts.emit('register', name, data)})
 
   // handles connections from the external side
   opts.externalServer = externalServer(opts)


### PR DESCRIPTION
- Introduce a data object where client can pass additional data to server:
```
var client = createClient({
  tunnelHost: 'localhost',
  tunnelPort: '9000',
  controlPort: '9001',
  name: 'upper-caser',
  port: '8080',
  data: {
    key1: 1,
    key2: 'text'
  }
  // secure: true
})
```

- Introduce "register" event on server:
```
server.on('register', (name, data) => {
  console.log('name', name);
  console.log('data', data);
});
```